### PR TITLE
Add EF Core InMemory storage for WeatherForecasts

### DIFF
--- a/CodexTest/CodexTest.csproj
+++ b/CodexTest/CodexTest.csproj
@@ -7,7 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.4.24266.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.4.24266.7" />
     </ItemGroup>
 
 </Project>

--- a/CodexTest/CodexTest.csproj
+++ b/CodexTest/CodexTest.csproj
@@ -9,7 +9,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.4.24266.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.4.24266.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.4.24266.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0-preview.4.24266.7" />
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0-preview.4.24266.7" />
     </ItemGroup>
 
 </Project>

--- a/CodexTest/CodexTest.http
+++ b/CodexTest/CodexTest.http
@@ -15,3 +15,16 @@ Content-Type: application/json
 }
 
 ###
+
+PATCH {{CodexTest_HostAddress}}/weatherforecast/1
+Content-Type: application/json-patch+json
+
+[
+  { "op": "replace", "path": "/summary", "value": "Hot" }
+]
+
+###
+
+DELETE {{CodexTest_HostAddress}}/weatherforecast/1
+
+###

--- a/CodexTest/CodexTest.http
+++ b/CodexTest/CodexTest.http
@@ -4,3 +4,14 @@ GET {{CodexTest_HostAddress}}/weatherforecast/
 Accept: application/json
 
 ###
+
+POST {{CodexTest_HostAddress}}/weatherforecast
+Content-Type: application/json
+
+{
+  "date": "2030-01-01",
+  "temperatureC": 25,
+  "summary": "Warm"
+}
+
+###

--- a/CodexTest/CodexTest.http
+++ b/CodexTest/CodexTest.http
@@ -28,3 +28,8 @@ Content-Type: application/json-patch+json
 DELETE {{CodexTest_HostAddress}}/weatherforecast/1
 
 ###
+
+GET {{CodexTest_HostAddress}}/rates
+Accept: application/json
+
+###

--- a/CodexTest/Program.cs
+++ b/CodexTest/Program.cs
@@ -1,10 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddDbContext<WeatherForecastDbContext>(options =>
+    options.UseInMemoryDatabase("WeatherDb"));
 
 var app = builder.Build();
+
+// Seed data
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<WeatherForecastDbContext>();
+    if (!db.Forecasts.Any())
+    {
+        var summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+        var forecast = Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = summaries[Random.Shared.Next(summaries.Length)]
+            }).ToArray();
+        db.Forecasts.AddRange(forecast);
+        db.SaveChanges();
+    }
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
@@ -14,28 +39,35 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-    {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
-    })
+app.MapGet("/weatherforecast", async (WeatherForecastDbContext db) =>
+    await db.Forecasts.ToListAsync())
     .WithName("GetWeatherForecast");
+
+app.MapPost("/weatherforecast", async (WeatherForecast forecast, WeatherForecastDbContext db) =>
+    {
+        db.Forecasts.Add(forecast);
+        await db.SaveChangesAsync();
+        return Results.Created($"/weatherforecast/{forecast.Id}", forecast);
+    })
+    .WithName("CreateWeatherForecast");
 
 app.Run();
 
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+class WeatherForecast
 {
+    public int Id { get; set; }
+    public DateOnly Date { get; set; }
+    public int TemperatureC { get; set; }
+    public string? Summary { get; set; }
+
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}
+
+class WeatherForecastDbContext : DbContext
+{
+    public WeatherForecastDbContext(DbContextOptions<WeatherForecastDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<WeatherForecast> Forecasts => Set<WeatherForecast>();
 }

--- a/CodexTest/appsettings.Development.json
+++ b/CodexTest/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=weather.db"
   }
 }

--- a/CodexTest/appsettings.json
+++ b/CodexTest/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=weather.db"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- add EF Core packages
- configure in-memory EF Core storage
- add a DbContext and model for `WeatherForecast`
- use EF Core to seed and expose GET/POST endpoints

## Testing
- `dotnet build CodexTest/CodexTest.sln -warnaserror` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597dcd74f883328d593286237537e9