### PR TITLE
Implement real weather and currency APIs

### DIFF
--- a/CodexTest/CodexTest.http
+++ b/CodexTest/CodexTest.http
@@ -1,6 +1,11 @@
 @CodexTest_HostAddress = http://localhost:5073
 
-GET {{CodexTest_HostAddress}}/weatherforecast/
+GET {{CodexTest_HostAddress}}/weather?location=London
+Accept: application/json
+
+###
+
+GET {{CodexTest_HostAddress}}/currency?base=USD
 Accept: application/json
 
 ###

--- a/CodexTest/Program.cs
+++ b/CodexTest/Program.cs
@@ -1,8 +1,11 @@
+using System.Net.Http.Json;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
@@ -14,28 +17,54 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
+app.MapGet("/weather", async (string location, IConfiguration config, HttpClient http) =>
     {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
+        var key = config["OpenWeather:ApiKey"];
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return Results.Problem("OpenWeather ApiKey is missing");
+        }
+
+        var url = $"https://api.openweathermap.org/data/2.5/weather?q={Uri.EscapeDataString(location)}&appid={key}&units=metric";
+
+        try
+        {
+            var data = await http.GetFromJsonAsync<OpenWeatherResponse>(url);
+            if (data is null)
+            {
+                return Results.NotFound();
+            }
+            return Results.Ok(new WeatherResult(data.Name, data.Main.Temp, data.Weather.FirstOrDefault()?.Description ?? string.Empty));
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem(ex.Message);
+        }
     })
-    .WithName("GetWeatherForecast");
+    .WithName("GetWeather");
+
+app.MapGet("/currency", async (string? baseCurrency, HttpClient http) =>
+    {
+        baseCurrency ??= "USD";
+        var url = $"https://api.exchangerate.host/latest?base={Uri.EscapeDataString(baseCurrency)}&symbols=USD,EUR,UAH";
+        try
+        {
+            var data = await http.GetFromJsonAsync<ExchangeRateResponse>(url);
+            return data is null ? Results.NotFound() : Results.Ok(data.Rates);
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem(ex.Message);
+        }
+    })
+    .WithName("GetCurrency");
 
 app.Run();
 
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}
+record OpenWeatherResponse(OpenWeatherMain Main, OpenWeatherWeather[] Weather, string Name);
+record OpenWeatherMain(double Temp);
+record OpenWeatherWeather(string Description);
+
+record WeatherResult(string City, double TemperatureC, string Description);
+
+record ExchangeRateResponse(Dictionary<string, decimal> Rates);

--- a/CodexTest/appsettings.json
+++ b/CodexTest/appsettings.json
@@ -6,4 +6,8 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "OpenWeather": {
+    "ApiKey": "YOUR_API_KEY"
+  }
 }


### PR DESCRIPTION
## Summary
- update example HTTP requests
- fetch weather data from OpenWeather
- fetch currency rates from exchangerate.host
- add OpenWeather API key placeholder

## Testing
- `dotnet build CodexTest/CodexTest.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598636f89c8332a06faf90369ac37a