### PR TITLE
Implement EF-backed Weather API

### DIFF
--- a/CodexTest.Tests/CodexTest.Tests.csproj
+++ b/CodexTest.Tests/CodexTest.Tests.csproj
@@ -1,5 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -13,6 +12,7 @@
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
+    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CodexTest.Tests/WeatherForecastEndpointTests.cs
+++ b/CodexTest.Tests/WeatherForecastEndpointTests.cs
@@ -1,30 +1,132 @@
 using System.Net;
 using System.Net.Http.Json;
+using CodexTest.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using CodexTest;
 
 namespace CodexTest.Tests;
 
-public class WeatherForecastEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+public class SqlServerFixture : IAsyncLifetime
 {
-    private readonly HttpClient _client;
+    public MsSqlTestcontainer Container { get; }
 
-    public WeatherForecastEndpointTests(WebApplicationFactory<Program> factory)
+    public SqlServerFixture()
     {
-        _client = factory.CreateClient();
+        Container = new TestcontainersBuilder<MsSqlTestcontainer>()
+            .WithDatabase(new MsSqlTestcontainerConfiguration { Password = "yourStrong(!)Password" })
+            .Build();
+    }
+
+    public async Task InitializeAsync() => await Container.StartAsync();
+
+    public async Task DisposeAsync() => await Container.DisposeAsync();
+}
+
+public class WeatherApiFactory : WebApplicationFactory<Program>
+{
+    private readonly string _connectionString;
+
+    public WeatherApiFactory(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(s => s.ServiceType == typeof(DbContextOptions<WeatherDbContext>));
+            if (descriptor != null)
+                services.Remove(descriptor);
+            services.AddDbContext<WeatherDbContext>(options => options.UseSqlServer(_connectionString));
+        });
+        return base.CreateHost(builder);
+    }
+}
+
+public class WeatherForecastEndpointTests : IClassFixture<SqlServerFixture>
+{
+    private readonly SqlServerFixture _fixture;
+
+    public WeatherForecastEndpointTests(SqlServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private HttpClient CreateClient()
+    {
+        var factory = new WeatherApiFactory(_fixture.Container.ConnectionString);
+        using var scope = factory.Services.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<WeatherDbContext>();
+        ctx.Database.EnsureCreated();
+        return factory.CreateClient();
     }
 
     [Fact]
-    public async Task GetWeatherForecast_ReturnsSuccessAndFiveRecords()
+    public async Task Post_CreatesForecast()
     {
-        var response = await _client.GetAsync("/weatherforecast");
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        var forecasts = await response.Content.ReadFromJsonAsync<TestForecast[]>();
-        Assert.NotNull(forecasts);
-        Assert.Equal(5, forecasts!.Length);
+        using var client = CreateClient();
+        var request = new WeatherForecastRequest(DateOnly.FromDateTime(DateTime.Today), 10, "Test");
+        var response = await client.PostAsJsonAsync("/weatherforecast", request);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
-    private record TestForecast(DateOnly Date, int TemperatureC, string? Summary);
-}
+    [Fact]
+    public async Task Get_ReturnsForecasts()
+    {
+        using var client = CreateClient();
+        var request = new WeatherForecastRequest(DateOnly.FromDateTime(DateTime.Today), 10, "Test");
+        var post = await client.PostAsJsonAsync("/weatherforecast", request);
+        var get = await client.GetAsync("/weatherforecast");
+        Assert.Equal(HttpStatusCode.OK, get.StatusCode);
+        var forecasts = await get.Content.ReadFromJsonAsync<WeatherForecastResponse[]>();
+        Assert.NotNull(forecasts);
+        Assert.NotEmpty(forecasts!);
+    }
 
+    [Fact]
+    public async Task Get_ById_ReturnsItem()
+    {
+        using var client = CreateClient();
+        var request = new WeatherForecastRequest(DateOnly.FromDateTime(DateTime.Today), 10, "Test");
+        var post = await client.PostAsJsonAsync("/weatherforecast", request);
+        var location = post.Headers.Location!.ToString();
+        var response = await client.GetAsync(location);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Put_UpdatesItem()
+    {
+        using var client = CreateClient();
+        var create = new WeatherForecastRequest(DateOnly.FromDateTime(DateTime.Today), 10, "Test");
+        var post = await client.PostAsJsonAsync("/weatherforecast", create);
+        var location = post.Headers.Location!.ToString();
+        var id = int.Parse(location.Split('/').Last());
+        var update = new WeatherForecastUpdateRequest(DateOnly.FromDateTime(DateTime.Today.AddDays(1)), 20, "Updated");
+        var put = await client.PutAsJsonAsync($"/weatherforecast/{id}", update);
+        Assert.Equal(HttpStatusCode.NoContent, put.StatusCode);
+        var get = await client.GetAsync($"/weatherforecast/{id}");
+        var item = await get.Content.ReadFromJsonAsync<WeatherForecastResponse>();
+        Assert.Equal(20, item!.TemperatureC);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesItem()
+    {
+        using var client = CreateClient();
+        var create = new WeatherForecastRequest(DateOnly.FromDateTime(DateTime.Today), 10, "Test");
+        var post = await client.PostAsJsonAsync("/weatherforecast", create);
+        var id = int.Parse(post.Headers.Location!.Segments.Last());
+        var delete = await client.DeleteAsync($"/weatherforecast/{id}");
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+        var get = await client.GetAsync($"/weatherforecast/{id}");
+        Assert.Equal(HttpStatusCode.NotFound, get.StatusCode);
+    }
+}

--- a/CodexTest/CodexTest.csproj
+++ b/CodexTest/CodexTest.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.6.24117.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.6.24117.3" />
+  </ItemGroup>
 
 </Project>

--- a/CodexTest/Domain/WeatherForecast.cs
+++ b/CodexTest/Domain/WeatherForecast.cs
@@ -1,0 +1,10 @@
+namespace CodexTest.Domain;
+
+public class WeatherForecast
+{
+    public int Id { get; set; }
+    public DateOnly Date { get; set; }
+    public int TemperatureC { get; set; }
+    public string? Summary { get; set; }
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/CodexTest/Entities/WeatherForecastEntity.cs
+++ b/CodexTest/Entities/WeatherForecastEntity.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CodexTest.Entities;
+
+public class WeatherForecastEntity
+{
+    [Key]
+    public int Id { get; set; }
+    public DateOnly Date { get; set; }
+    public int TemperatureC { get; set; }
+    public string? Summary { get; set; }
+}

--- a/CodexTest/Mappings/WeatherMappings.cs
+++ b/CodexTest/Mappings/WeatherMappings.cs
@@ -1,0 +1,47 @@
+using CodexTest.Domain;
+using CodexTest.Entities;
+using CodexTest.Models;
+
+namespace CodexTest.Mappings;
+
+public static class WeatherMappings
+{
+    public static WeatherForecastEntity ToEntity(this WeatherForecast model) => new()
+    {
+        Id = model.Id,
+        Date = model.Date,
+        TemperatureC = model.TemperatureC,
+        Summary = model.Summary
+    };
+
+    public static WeatherForecast ToDomain(this WeatherForecastEntity entity) => new()
+    {
+        Id = entity.Id,
+        Date = entity.Date,
+        TemperatureC = entity.TemperatureC,
+        Summary = entity.Summary
+    };
+
+    public static WeatherForecast ToDomain(this WeatherForecastRequest request) => new()
+    {
+        Date = request.Date,
+        TemperatureC = request.TemperatureC,
+        Summary = request.Summary
+    };
+
+    public static WeatherForecast ToDomain(this WeatherForecastUpdateRequest request, int id) => new()
+    {
+        Id = id,
+        Date = request.Date,
+        TemperatureC = request.TemperatureC,
+        Summary = request.Summary
+    };
+
+    public static WeatherForecastResponse ToResponse(this WeatherForecast model) => new()
+    {
+        Id = model.Id,
+        Date = model.Date,
+        TemperatureC = model.TemperatureC,
+        Summary = model.Summary
+    };
+}

--- a/CodexTest/Models/WeatherForecastRequest.cs
+++ b/CodexTest/Models/WeatherForecastRequest.cs
@@ -1,0 +1,3 @@
+namespace CodexTest.Models;
+
+public record WeatherForecastRequest(DateOnly Date, int TemperatureC, string? Summary);

--- a/CodexTest/Models/WeatherForecastResponse.cs
+++ b/CodexTest/Models/WeatherForecastResponse.cs
@@ -1,0 +1,10 @@
+namespace CodexTest.Models;
+
+public class WeatherForecastResponse
+{
+    public int Id { get; set; }
+    public DateOnly Date { get; set; }
+    public int TemperatureC { get; set; }
+    public string? Summary { get; set; }
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/CodexTest/Models/WeatherForecastUpdateRequest.cs
+++ b/CodexTest/Models/WeatherForecastUpdateRequest.cs
@@ -1,0 +1,3 @@
+namespace CodexTest.Models;
+
+public record WeatherForecastUpdateRequest(DateOnly Date, int TemperatureC, string? Summary);

--- a/CodexTest/Program.cs
+++ b/CodexTest/Program.cs
@@ -1,12 +1,29 @@
+using CodexTest;
+using CodexTest.Mappings;
+using CodexTest.Models;
+using CodexTest.Repositories;
+using CodexTest.Services;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+
+builder.Services.AddDbContext<WeatherDbContext>(options => options.UseSqlServer(connectionString));
+
+builder.Services.AddScoped<IWeatherRepository, WeatherRepository>();
+builder.Services.AddScoped<IWeatherService, WeatherService>();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<WeatherDbContext>();
+    db.Database.EnsureCreated();
+}
+
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
@@ -14,30 +31,45 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-var summaries = new[]
+app.MapGet("/weatherforecast", async (IWeatherService service) =>
 {
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
+    var forecasts = await service.GetAllAsync();
+    return forecasts.Select(f => f.ToResponse());
+}).WithName("GetWeatherForecast");
 
-app.MapGet("/weatherforecast", () =>
-    {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
-    })
-    .WithName("GetWeatherForecast");
+app.MapGet("/weatherforecast/{id}", async (int id, IWeatherService service) =>
+{
+    var forecast = await service.GetByIdAsync(id);
+    return forecast is null ? Results.NotFound() : Results.Ok(forecast.ToResponse());
+}).WithName("GetWeatherForecastById");
+
+app.MapPost("/weatherforecast", async (WeatherForecastRequest request, IWeatherService service) =>
+{
+    var id = await service.CreateAsync(request.ToDomain());
+    return Results.Created($"/weatherforecast/{id}", null);
+}).WithName("CreateWeatherForecast");
+
+app.MapPut("/weatherforecast/{id}", async (int id, WeatherForecastUpdateRequest request, IWeatherService service) =>
+{
+    var existing = await service.GetByIdAsync(id);
+    if (existing is null)
+        return Results.NotFound();
+
+    var model = request.ToDomain(id);
+    await service.UpdateAsync(model);
+    return Results.NoContent();
+}).WithName("UpdateWeatherForecast");
+
+app.MapDelete("/weatherforecast/{id}", async (int id, IWeatherService service) =>
+{
+    var existing = await service.GetByIdAsync(id);
+    if (existing is null)
+        return Results.NotFound();
+
+    await service.DeleteAsync(id);
+    return Results.NoContent();
+}).WithName("DeleteWeatherForecast");
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}
 
 public partial class Program { }

--- a/CodexTest/Repositories/IWeatherRepository.cs
+++ b/CodexTest/Repositories/IWeatherRepository.cs
@@ -1,0 +1,12 @@
+using CodexTest.Entities;
+
+namespace CodexTest.Repositories;
+
+public interface IWeatherRepository
+{
+    Task<List<WeatherForecastEntity>> GetAllAsync();
+    Task<WeatherForecastEntity?> GetByIdAsync(int id);
+    Task<int> CreateAsync(WeatherForecastEntity forecast);
+    Task UpdateAsync(WeatherForecastEntity forecast);
+    Task DeleteAsync(int id);
+}

--- a/CodexTest/Repositories/WeatherRepository.cs
+++ b/CodexTest/Repositories/WeatherRepository.cs
@@ -1,0 +1,41 @@
+using CodexTest.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CodexTest.Repositories;
+
+public class WeatherRepository : IWeatherRepository
+{
+    private readonly WeatherDbContext _context;
+
+    public WeatherRepository(WeatherDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> CreateAsync(WeatherForecastEntity forecast)
+    {
+        _context.Forecasts.Add(forecast);
+        await _context.SaveChangesAsync();
+        return forecast.Id;
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await _context.Forecasts.FindAsync(id);
+        if (entity is not null)
+        {
+            _context.Forecasts.Remove(entity);
+            await _context.SaveChangesAsync();
+        }
+    }
+
+    public async Task<List<WeatherForecastEntity>> GetAllAsync() => await _context.Forecasts.ToListAsync();
+
+    public async Task<WeatherForecastEntity?> GetByIdAsync(int id) => await _context.Forecasts.FindAsync(id);
+
+    public async Task UpdateAsync(WeatherForecastEntity forecast)
+    {
+        _context.Forecasts.Update(forecast);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/CodexTest/Services/IWeatherService.cs
+++ b/CodexTest/Services/IWeatherService.cs
@@ -1,0 +1,12 @@
+using CodexTest.Domain;
+
+namespace CodexTest.Services;
+
+public interface IWeatherService
+{
+    Task<List<WeatherForecast>> GetAllAsync();
+    Task<WeatherForecast?> GetByIdAsync(int id);
+    Task<int> CreateAsync(WeatherForecast forecast);
+    Task UpdateAsync(WeatherForecast forecast);
+    Task DeleteAsync(int id);
+}

--- a/CodexTest/Services/WeatherService.cs
+++ b/CodexTest/Services/WeatherService.cs
@@ -1,0 +1,36 @@
+using CodexTest.Domain;
+using CodexTest.Mappings;
+using CodexTest.Repositories;
+
+namespace CodexTest.Services;
+
+public class WeatherService : IWeatherService
+{
+    private readonly IWeatherRepository _repository;
+
+    public WeatherService(IWeatherRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<int> CreateAsync(WeatherForecast forecast)
+    {
+        var id = await _repository.CreateAsync(forecast.ToEntity());
+        forecast.Id = id;
+        return id;
+    }
+
+    public async Task DeleteAsync(int id) => await _repository.DeleteAsync(id);
+
+    public async Task<List<WeatherForecast>> GetAllAsync() =>
+        (await _repository.GetAllAsync()).Select(e => e.ToDomain()).ToList();
+
+    public async Task<WeatherForecast?> GetByIdAsync(int id)
+    {
+        var entity = await _repository.GetByIdAsync(id);
+        return entity?.ToDomain();
+    }
+
+    public async Task UpdateAsync(WeatherForecast forecast) =>
+        await _repository.UpdateAsync(forecast.ToEntity());
+}

--- a/CodexTest/WeatherDbContext.cs
+++ b/CodexTest/WeatherDbContext.cs
@@ -1,0 +1,13 @@
+using CodexTest.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CodexTest;
+
+public class WeatherDbContext : DbContext
+{
+    public WeatherDbContext(DbContextOptions<WeatherDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<WeatherForecastEntity> Forecasts => Set<WeatherForecastEntity>();
+}

--- a/CodexTest/appsettings.Development.json
+++ b/CodexTest/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=WeatherDb;User Id=sa;Password=Your_password123;TrustServerCertificate=True"
   }
 }

--- a/CodexTest/appsettings.json
+++ b/CodexTest/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=WeatherDb;User Id=sa;Password=Your_password123;TrustServerCertificate=True"
+  }
 }


### PR DESCRIPTION
## Summary
- use EF Core SQL Server DbContext and configure connection string
- add repository/service layers for weather data
- define entity, domain and request/response models with mapping extensions
- expose CRUD endpoints that talk to the database
- add integration tests using Testcontainers and SQL Server

## Testing
- `dotnet test CodexTest.Tests/CodexTest.Tests.csproj -c Release` *(fails: Connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685b11c51b4c833285595c84ae0332e4